### PR TITLE
Add basic auth support

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,23 @@
+// Basic polling script for inverter API
+// Polls /api/status and /api/config with optional Basic authentication
+
+const user = process.env.INVERTER_USER || '';
+const pass = process.env.INVERTER_PASS || '';
+
+const headers = {};
+if (user || pass) {
+  const token = Buffer.from(`${user}:${pass}`).toString('base64');
+  headers['Authorization'] = `Basic ${token}`;
+}
+
+async function fetchStatus() {
+  const res = await fetch('/api/status', { headers });
+  return res.json();
+}
+
+async function fetchConfig() {
+  const res = await fetch('/api/config', { headers });
+  return res.json();
+}
+
+module.exports = { fetchStatus, fetchConfig };


### PR DESCRIPTION
## Summary
- add a simple polling module and include Basic Authentication headers using `INVERTER_USER`/`INVERTER_PASS`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686c07099b38832292a9517e79971418