### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,34 @@
+name: Windows Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Package for Windows
+        run: npm run package-win
+
+      - name: Upload Installer
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-installer
+          path: dist/windows-installer.exe
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds on Windows and uploads the installer artifact

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c262385b88322a487988f24280967